### PR TITLE
AE-2273: enabled cert report for crypto bom pipeline

### DIFF
--- a/policies/security-policy/security-policy-cert-eu.json
+++ b/policies/security-policy/security-policy-cert-eu.json
@@ -1,0 +1,139 @@
+{
+  "name": "Workbench Security Policy Configuration",
+  "description": "See the security-policy.md file for more details on what configurations to activate in what cases.",
+  "version": "1",
+  "configurations": [
+    {
+      "id": "assessment_enrichment_configuration",
+      "configuration": {
+        "insignificantThreshold": 7.0,
+        "includeScoreThreshold": -1.0,
+        "vulnerabilityStatusDisplayMapperName": "unmodified",
+        "priorityScoreConfiguration": {
+          "vulnerabilityStatus": {
+            "set": {
+              "void": 0.0,
+              "not applicable": 0.0
+            },
+            "add": {
+              "applicable": 0.5
+            }
+          },
+          "eol": {
+            "noExtendedSupport": {
+              "supportValid": 0.0,
+              "supportEndingSoon": 1.0,
+              "supportExpired": 1.5
+            },
+            "extendedSupport": {
+              "supportValid": 0.0,
+              "supportEndingSoon": 0.5,
+              "extendedSupportValid": 1.0,
+              "extendedSupportEndingSoon": 1.2,
+              "extendedSupportExpired": 1.5
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "base_configuration",
+      "configuration": {
+        "insignificantThreshold": 0.0,
+        "vulnerabilityStatusDisplayMapperName": "abstracted",
+        "includeVulnerabilitiesWithAdvisoryProviders": [ { "src": "CERT_EU", "impl": "CERT_EU", "st": "sa" } ]
+      }
+    },
+    {
+      "id": "vulnerability_configuration",
+      "extends": [ "base_configuration" ],
+      "configuration": {
+        "priorityScoreConfiguration": {
+          "vulnerabilityStatus": {
+            "set": {
+              "void": 0.0,
+              "not applicable": 0.0
+            },
+            "add": {
+              "applicable": 0.5
+            }
+          },
+          "eol": {
+            "noExtendedSupport": {
+              "supportValid": 0.0,
+              "supportEndingSoon": 1.0,
+              "supportExpired": 1.5
+            },
+            "extendedSupport": {
+              "supportValid": 0.0,
+              "supportEndingSoon": 0.5,
+              "extendedSupportValid": 1.0,
+              "extendedSupportEndingSoon": 1.2,
+              "extendedSupportExpired": 1.5
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "cert_configuration",
+      "extends": [ "base_configuration" ],
+      "configuration": {
+        "includeAdvisoryProviders": [ { "src": "CERT_EU", "impl": "CERT_EU", "st": "sa" } ],
+        "generateOverviewTablesForAdvisories": [ { "src": "CERT_EU", "impl": "CERT_EU", "st": "sa" } ],
+        "includeAdvisoryTypes": [ "alert", "news", "notice" ],
+        "priorityScoreConfiguration": {
+          "vulnerabilityStatus": {
+            "set": {
+              "void": 0.0,
+              "not applicable": 0.0
+            },
+            "add": {
+              "applicable": 0.0
+            }
+          },
+          "epss": {
+            "min": 0.5,
+            "f": 0.0,
+            "F": 0.0
+          },
+          "kev": {
+            "exploit": 0.0,
+            "ransomware": 0.0
+          },
+          "eol": {
+            "noExtendedSupport": {
+              "supportValid": 0.0,
+              "supportEndingSoon": 0.0,
+              "supportExpired": 0.0
+            },
+            "extendedSupport": {
+              "supportValid": 0.0,
+              "supportEndingSoon": 0.0,
+              "extendedSupportValid": 0.0,
+              "extendedSupportEndingSoon": 0.0,
+              "extendedSupportExpired": 0.0
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "cert_extended_configuration",
+      "extends": [ "cert_configuration" ],
+      "configuration": {
+        "includeVulnerabilitiesWithAdvisoryReviewStatus": [ "new", "in review", "reviewed" ]
+      }
+    },
+    {
+      "id": "summary-report-overall",
+      "configuration": {
+        "vulnerabilityStatusDisplayMapperName": "default",
+        "includeAdvisoryTypes": [
+          "alert",
+          "news"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/scripts/pipelines/001_crypto-bom-pipeline_en.sh
+++ b/tests/scripts/pipelines/001_crypto-bom-pipeline_en.sh
@@ -48,9 +48,13 @@ set_global_variables() {
   create_workspace_variables "$WORKSPACE_DIR/crypto-bom-SNAPSHOT" "crypto-bom-SNAPSHOT"
 
   ENV_REPORT_TEMPLATE_DIR="$WORKBENCH_DIR/templates/report-template"
-  PARAM_SECURITY_POLICY_FILE="$WORKBENCH_DIR/policies/security-policy/security-policy.json"
+  PARAM_SECURITY_POLICY_FILE="$WORKBENCH_DIR/policies/security-policy/security-policy-cert-eu.json"
 
-  ENV_VR_DESCRIPTOR_FILE="$WORKBENCH_DIR/descriptors/asset-descriptor_GENERIC-vulnerability-report.yaml"
+  ENV_DESCRIPTOR_DIR="$WORKBENCH_DIR/descriptors"
+  ENV_VR_DESCRIPTOR_FILE="$WORKBENCH_DIR/asset-descriptor_GENERIC-vulnerability-report.yaml"
+  ENV_CR_DESCRIPTOR_FILE="$ENV_DESCRIPTOR_DIR/asset-descriptor_GENERIC-cert-report.yaml"
+
+  ENV_LANGUAGE="en"
 
   TENANT_ID="metaeffekt"
   ASSET_ID="crypto-bom"
@@ -95,7 +99,6 @@ enrich_inventory() {
   CMD+=("-Doutput.inventory.file=$ADVISED_INVENTORY_FILE")
   CMD+=("-Doutput.tmp.dir=$PROCESSOR_TMP_DIR")
 
-  CMD+=("-Dparam.security.policy.file=$PARAM_SECURITY_POLICY_FILE")
   CMD+=("-Dparam.security.policy.file=$PARAM_SECURITY_POLICY_FILE")
   CMD+=("-Dparam.security.policy.active.ids=$SECURITY_POLICY_ACTIVE_IDS")
   CMD+=("-Dparam.dashboard.title=CryptoBOM SNAPSHOT Assessment")
@@ -190,6 +193,45 @@ generate_vulnerability_report() {
   pass_command_info_to_logger "generate_vulnerability-report"
 }
 
+generate_cert_report() {
+  OUTPUT_CR_FILE="$REPORTED_DIR/cert-report/$ENV_LANGUAGE/cert-report-$ENV_LANGUAGE.pdf"
+  OUTPUT_COMPUTED_INVENTORY_DIR="$ADDITIONAL_DIR/report"
+
+  PARAM_DOCUMENT_TYPE="CR"
+  PARAM_ASSET_ID="CryptoBOM"
+  PARAM_ASSET_NAME="CryptoBOM"
+  PARAM_ASSET_VERSION="SNAPSHOT"
+  PARAM_PRODUCT_NAME="CryptoBOM"
+  PARAM_PRODUCT_VERSION="SNAPSHOT"
+  PARAM_PRODUCT_WATERMARK="CryptoBOM"
+  PARAM_OVERVIEW_ADVISORS="CERT_EU"
+
+  CMD=(mvn -f "$KONTINUUM_PROCESSORS_DIR/report/report_create-document.xml" verify)
+  [ -n "${AE_CORE_VERSION:-}" ] && CMD+=("-Dae.core.version=$AE_CORE_VERSION")
+  [ -n "${AE_ARTIFACT_ANALYSIS_VERSION:-}" ] && CMD+=("-Dae.artifact.analysis.version=$AE_ARTIFACT_ANALYSIS_VERSION")
+  CMD+=("-Dinput.inventory.dir=$GROUPED_CR_DIR")
+
+  CMD+=("-Doutput.document.file=$OUTPUT_CR_FILE")
+
+  CMD+=("-Dparam.asset.descriptor.file=$ENV_CR_DESCRIPTOR_FILE")
+  CMD+=("-Dparam.asset.id=$PARAM_ASSET_ID")
+  CMD+=("-Dparam.asset.name=$PARAM_ASSET_NAME")
+  CMD+=("-Dparam.asset.version=$PARAM_ASSET_VERSION")
+  CMD+=("-Dparam.product.version=$PARAM_PRODUCT_VERSION")
+  CMD+=("-Dparam.product.name=$PARAM_PRODUCT_NAME")
+  CMD+=("-Dparam.product.watermark=$PARAM_PRODUCT_WATERMARK")
+  CMD+=("-Dparam.document.type=$PARAM_DOCUMENT_TYPE")
+  CMD+=("-Dparam.document.language=$ENV_LANGUAGE")
+  CMD+=("-Dparam.overview.advisors=$PARAM_OVERVIEW_ADVISORS")
+  CMD+=("-Dparam.property.selector.organization=metaeffekt")
+
+  CMD+=("-Denv.vulnerability.mirror.dir=$EXTERNAL_VULNERABILITY_MIRROR_DIR/.database")
+  CMD+=("-Denv.workbench.dir=$WORKBENCH_DIR")
+  CMD+=("-Denv.kontinuum.dir=$EXTERNAL_KONTINUUM_DIR")
+
+  pass_command_info_to_logger "create_cert_report"
+}
+
 main() {
   source_preload
   set_global_variables
@@ -200,8 +242,10 @@ main() {
 
   copy_to_grouped
 
+  generate_cert_report
+  generate_vulnerability_report
   generate_vulnerability_assessment_dashboard
-  # generate_vulnerability_report
+
 }
 
 main "$@"


### PR DESCRIPTION
This does not work currently as the inventory does not seem to have the right information to report on CERT-EU, while I created a second security-policy to account for using CERT-EU it still seems to fail on generating the statistics for the cert report. Enabling cert reports for other pipelines should look similar.